### PR TITLE
Fix over scroll

### DIFF
--- a/components/channel/Container/Content.vue
+++ b/components/channel/Container/Content.vue
@@ -523,9 +523,11 @@ onActivated(() => {
     } else if (latestReadEl !== null) {
       //console.log("/channel/[id] :: onMounted : (最新既読Id)スクロールします->", scrollPosition);
       //最新既読Idへ
+      /*
       document.getElementById("ChannelContainerContent")?.scrollTo({
         top: latestReadEl.getBoundingClientRect().top,
       });
+      */
     }
 
     /*

--- a/components/channel/Container/Content.vue
+++ b/components/channel/Container/Content.vue
@@ -67,19 +67,12 @@ const fetchOlderHistory = () => {
     oldestMessageId = getHistoryFromChannel(props.channelInfo.channelId)[
       lengthOfHistory - 1
     ].messageId;
-    console.log(
-      "/channel/:id :: fetchOlderHistory : oldestMessageContent->",
-      getHistoryFromChannel(props.channelInfo.channelId)[lengthOfHistory - 1]
-        .content,
-    );
+    
+    //スクロールするメッセIdとして格納
+    messageIdToScroll.value = oldestMessageId;
   } catch (e) {
     return;
   }
-
-  console.log(
-    "/channel/:id :: fetchOlderHistory : oldestMessageId->",
-    oldestMessageId,
-  );
 
   //履歴を取得中であるとグローバルで設定
   getAppStatus.value.fetchingHistory = true;
@@ -426,7 +419,7 @@ watch(atLatestMessage, (newValue, oldValue) => {
 });
 
 // *************  履歴監視の取得状態監視  ************* //
-//履歴の更新を監視
+//履歴の更新を監視、スクロールする
 watch(
   getAppStatus,
   (newValue, oldValue) => {
@@ -434,17 +427,11 @@ watch(
       //console.log("/channel/:id :: watch(getHistory...) : 変更された?", newValue, oldValue);
 
       //履歴を取り終えたとき、履歴を取得した位置からスクロールする
-      if (displayDirection.value === "newer" && !newValue.fetchingHistory) {
+      if (!newValue.fetchingHistory) {
         //console.log("/channe/[id] :: watch(getAppStatus) : 最後->", getHistoryAvailability(props.channelInfo.channelId).atEnd);
         try {
-          //要素DOMオブジェクト取得
-          const el = document.getElementById(`msg${messageIdToScroll.value}`);
-          //要素がnullじゃないならその要素へスクロール
-          if (el !== null) {
-            document.getElementById("ChannelContainerContent")?.scrollTo({
-              top: el.getBoundingClientRect().top,
-            });
-          }
+          //履歴取得し始めた位置へスクロールさせる
+          document.getElementById(`msg${messageIdToScroll.value}`)?.scrollIntoView(true);
 
           //履歴取得時一番下なら新着削除
           if (y.value === 0) {

--- a/components/channel/Container/Content.vue
+++ b/components/channel/Container/Content.vue
@@ -19,7 +19,7 @@ import {
 
 //スクロール位置取得用
 const ChannelContainerContent = ref<HTMLElement | null>(null);
-const { y, arrivedState } = useScroll(ChannelContainerContent);
+const { y } = useScroll(ChannelContainerContent);
 //ウィンドウのフォーカス取得用
 const windowFocused = useWindowFocus();
 

--- a/components/channel/Container/Content/MessageRender.vue
+++ b/components/channel/Container/Content/MessageRender.vue
@@ -60,6 +60,22 @@ onMounted(() => {
       });
     }
   }
+
+  //もし新着メッセの最初ならレンダー時、自動スクロールさせる
+  if (
+    (
+      getMessageReadTimeBefore.value(propsMessage.message.channelId)
+        ===
+      propsMessage.message.time
+    )
+      &&
+    propsMessage.index !== 0
+  ) {
+    nextTick(() => {
+      document.getElementById(`msgBody${propsMessage.message.messageId}`)?.scrollIntoView(true);
+      console.log("スクロールしたつもり", document.getElementById(`msgBody${propsMessage.message.messageId}`));
+    });
+  }
 });
 </script>
 
@@ -75,6 +91,7 @@ onMounted(() => {
     @mouseover="() => {if (!isScrolling) {displayHoverMenu=true}}"
     @mouseleave="displayHoverMenu=false"
     class="d-flex pr-2"
+    :id="`msgBody${propsMessage.message.messageId}`"
     style="width:100%; height:100%; position:relative;"
   >
 

--- a/socketHandlers/getMessageReadTime.ts
+++ b/socketHandlers/getMessageReadTime.ts
@@ -40,6 +40,7 @@ export default function getMessageReadTime(socket: Socket): void {
               includeThisPosition: true,
               fetchDirection: "older",
             },
+            historyLength: 2
           });
         }
       }

--- a/stores/history.ts
+++ b/stores/history.ts
@@ -29,7 +29,7 @@ const cleanHistory = (addingLength:number, excludingChannelId:string) => {
     }
   }
 
-  console.log("history :: cleanHistory : 削るチャンネル->", {largestChannelId}, {largestLength}, {totalLength});
+  //console.log("history :: cleanHistory : 削るチャンネル->", {largestChannelId}, {largestLength}, {totalLength});
 
   //もし総量が400未満なら停止
   if (totalLength < 400) return;

--- a/stores/history.ts
+++ b/stores/history.ts
@@ -129,6 +129,7 @@ export const useHistory = defineStore("history", {
         reaction: {},
         isEdited: false,
         fileId: [],
+        isSystemMessage: false
       };
       return blankMessage;
     },


### PR DESCRIPTION
Chromeにて、上に向かって履歴を取得したとき取得し始めた位置にスクロールせず、勝手に一番上のスケルトンローダー部分にスクロールされてしまう問題
（Firefoxは理想通りに動く）